### PR TITLE
feat: add support for `/path/:slug/path/:slug` pattern in paths

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -30,20 +30,50 @@ func TestRoutes(t *testing.T) {
 				"two": "two",
 			},
 		},
+		{
+			route: "/params/:one/fixed/:two",
+			path:  "/params/one/fixed/two",
+			variables: map[string]string{
+				"one": "one",
+				"two": "two",
+			},
+		},
+		{
+			route: "/params/:one/fixed2/:two",
+			path:  "/params/one/fixed2/two",
+			variables: map[string]string{
+				"one": "one",
+				"two": "two",
+			},
+		},
+		{
+			route: "/params/:one/:middle/:two",
+			path:  "/params/one/middle/two",
+			variables: map[string]string{
+				"one":    "one",
+				"two":    "two",
+				"middle": "middle",
+			},
+		},
 	}
 
+	var lastRoute string
 	routes := NewRoutes()
 	for _, test := range tests {
 		test := test
 		routes.Add(test.route, func(res *Response, req *Request) {
+			lastRoute = test.route
 		})
 	}
 
 	for _, test := range tests {
 		t.Run(test.route, func(t *testing.T) {
-			_, params, ok := routes.Get(test.path)
+			f, params, ok := routes.Get(test.path)
 			require.True(t, ok)
 			require.Equal(t, test.variables, params)
+
+			f(nil, nil)
+			require.Equal(t, test.route, lastRoute)
 		})
 	}
 }


### PR DESCRIPTION
Previously matching fixed parts after a variable was not supported.

Note: When two routes can match the same path the first one will be
used. For example, if these two routes are registered:

* `/path/:var/:var3/:var2`
* `/path/:var/fixed/:var2`

The path `/path/one/fixed/two` will match the first route.