### PR TITLE
feat: add banner colors

### DIFF
--- a/minima.go
+++ b/minima.go
@@ -55,16 +55,16 @@ type Minima struct {
 	drain      time.Duration
 }
 
+var (
+	red    = "\u001b[31m"
+	green  = "\u001b[32m"
+	yellow = "\u001b[33m"
+	blue   = "\u001b[34m"
+	reset  = "\u001b[0m"
+)
+
 const (
 	version = "1.1.2"
-	banner  = `	
-  __  __  _  __  _  _  __  __   ____  
- |  \/  || ||  \| || ||  \/  | / () \ 
- |_|\/|_||_||_|\__||_||_|\/|_|/__/\__\ %s
- The Go framework to scale
-___________________________________________
- Server started at port %v                                                                              
-`
 )
 
 /**
@@ -98,11 +98,23 @@ func New() *Minima {
  */
 func (m *Minima) Listen(addr string) error {
 	if m.started {
-		log.Panicf("Minimia's instance is already running at %s.", m.server.Addr)
+		log.Panicf("Minima's instance is already running at %s.", m.server.Addr)
 	}
 	m.server = &http.Server{Addr: addr, Handler: m}
 	m.started = true
-	fmt.Printf(banner, version, addr)
+
+	banner := fmt.Sprintf(`	
+%s  __  __  _  __  _  _  __  __   ____  
+%s |  \/  || ||  \| || ||  \/  | / () \ 
+%s |_|\/|_||_||_|\__||_||_|\/|_|/__/\__\ %s
+%s The Go framework to scale
+%s___________________________________________
+%s Server started at port %s %v
+%s                                                                      
+`, green, green, green, version, blue, red, blue, yellow, addr, reset)
+
+	fmt.Println(banner)
+
 	return m.server.ListenAndServe()
 }
 


### PR DESCRIPTION
This PR adds colors to the main Minima banner

This is what it should look like (at least with the One Dark Pro terminal theme)

![image](https://user-images.githubusercontent.com/38729705/156926765-22582363-8aa2-4be6-aff5-063fd8fc880e.png)

Should work fine on zsh and Powershell. Colors might not be displayed correctly on Git Bash on Windows though, due to improper terminal configuration. To fix that, you could use a live-reloading command line utility such as [Air](https://github.com/cosmtrek/air) and the issue should be fixed.